### PR TITLE
update scoreboard data to use epoch instead of date/time

### DIFF
--- a/backend/services/scoreboard_service.py
+++ b/backend/services/scoreboard_service.py
@@ -39,8 +39,9 @@ def process_games(raw_data: dict):
                     if home_team.get('conferences') else None
                 )
                 },
-            'date': game.get('startDate'),
-            'time': game.get('startTime')
+            'epoch': game.get('startTimeEpoch')
+            # 'date': game.get('startDate'),
+            # 'time': game.get('startTimeEpoch')
         }
         processed_games.append(game_data)
 

--- a/frontend/src/components/ScoreCard.jsx
+++ b/frontend/src/components/ScoreCard.jsx
@@ -7,8 +7,7 @@ const ScoreCard = ({ game }) => {
     home,
     away,
     game_state,
-    date,
-    time
+    epoch
   } = game;
 
   const homeTeam = home?.names?.short || "Home";
@@ -25,8 +24,8 @@ const ScoreCard = ({ game }) => {
     : "Unknown";
 
   // TODO: this kind of formatting could be done on the backend side to reduce frontend overhead.
-  const getFormattedDate = (date) => {
-    const dateObject = new Date(date);
+  const getFormattedDate = (epoch) => {
+    const dateObject = new Date(epoch*1000);
     return dateObject.toLocaleDateString('en-US', {
       year: '2-digit',
       month: 'short',
@@ -34,6 +33,15 @@ const ScoreCard = ({ game }) => {
     });
   };
 
+  const getFormattedTime = (epoch) => {
+    const dateObject = new Date(epoch*1000);
+    return dateObject.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true
+    })
+  }
+  
   const getStatusClass = (game_state) => {
     if (game_state.isFinished) return styles.scoreCardStatusFinal;
     if (game_state.isLive) return styles.scoreCardStatusLive;
@@ -51,7 +59,7 @@ const ScoreCard = ({ game }) => {
       </div>
 
       <div className={styles.scoreCardDate}>
-        {date ? getFormattedDate(date) : "TBD"} • {time || ""}
+        {epoch ? getFormattedDate(epoch) : "TBD"} • {getFormattedTime(epoch) || ""}
       </div>
 
       <div className={styles.scoreCardTeams}>


### PR DESCRIPTION
Previously, data for the scoreboard was utilizing date/time, but a more simplified approach, with better time zone support can be done using the epoch field instead.