### PR TITLE
Tweak date stuff for homescreen

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -5,13 +5,14 @@ import { appConfig } from "../constants";
 import api from "../services/api";
 import styles from "../styles/pages/HomePage.module.css";
 import { getCurrentWeek } from "../utils/helpers";
+import { getCurrentYear } from "../utils/helpers";
 import LoadingSpinner from "../components/LoadingSpinner";
 
 const HomePage = () => {
   const [selectedConference, setSelectedConference] = useState("All");
   const [selectedStatus, setSelectedStatus] = useState("All");
   const [selectedWeek, setSelectedWeek] = useState(getCurrentWeek());
-  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+  const [selectedYear, setSelectedYear] = useState(getCurrentYear());
   const [selectedDate, setSelectedDate] = useState("All");
   const [gameData, setGameData] = useState(null);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -37,23 +37,14 @@ export const debounce = (func, wait) => {
 // Get current week
 export const getCurrentWeek = () => {
   const startDate = new Date();
-  startDate.setMonth(7); // start-end dates hardcoded in, might wanna change this later on for future season reusability
+  startDate.setMonth(7);
   startDate.setDate(23);
-
-  const endDate = new Date();
-  endDate.setMonth(11);
-  endDate.setDate(13);
 
   const currentDate = new Date();
 
-  if (currentDate.getMonth() < 7) return 1;
-  if (currentDate.getMonth() > 11) {
-    // Calculate weeks for December and beyond
-    const daysSinceStart = Math.floor(
-      (currentDate - startDate) / (1000 * 60 * 60 * 24)
-    );
-    const weeks = Math.floor(daysSinceStart / 7 + 1);
-    return weeks > 19 ? 19 : weeks;
+  if (currentDate.getMonth() < 7)
+  {
+    return 19;
   }
 
   const daysSinceStart = Math.floor(
@@ -64,3 +55,11 @@ export const getCurrentWeek = () => {
 
   return weeks > 19 ? 19 : weeks;
 };
+
+export const getCurrentYear = () => {
+  const currentDate = new Date();
+  if (currentDate.getMonth() < 7) {
+    return currentDate.getFullYear() - 1;
+  }
+  return currentDate.getFullYear();
+}


### PR DESCRIPTION
When in offseason the homepage will display week 1 of the current year, which would show a 'No scores found matching your filters.' screen.

Fix:
Added: getCurrentYear() function for improved date accuracy
Now, if the user is in the offseason, the app will default 
to the final week of the previous season.