### PR TITLE
Remove route-transition animation causing nav flicker

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,9 +32,14 @@ function RoutePrefetcher() {
   return null;
 }
 
-// Wraps the routed page in a container keyed by pathname, so each navigation
-// remounts it and replays a short fade-in (see `.pageFade` in index.css).
-// Keyed on pathname only, so in-page state changes (filters, week) don't fade.
+// Wraps the routed page in a plain layout container (see `.routeOutlet` in
+// index.css — flex:1 so the page fills the space below the persistent
+// header). Previously this div was keyed by pathname to force a remount and
+// replay a fade-in animation on every navigation; that key made the wrapper
+// itself (and everything inside it) tear down and rebuild on every nav,
+// which is exactly what produced the visible flicker. No key, no animation:
+// <Routes> still swaps the matched page normally, but nothing above it
+// remounts or fades.
 // Deliberately does NOT include the Header/Navigation — those live once in
 // <App> outside of <Routes> so they never remount (and the logo never
 // re-decodes/blinks) when navigating between tabs.
@@ -42,7 +47,7 @@ function AnimatedRoutes() {
   const location = useLocation();
 
   return (
-    <div key={location.pathname} className="pageFade">
+    <div className="routeOutlet">
       <Routes location={location}>
         <Route path="/" element={<HomePage />} />
         <Route path="/rankings" element={<RankingsPage />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,8 @@ import TeamsPage from "./pages/TeamsPage";
 import ComparisonPage from "./pages/ComparisonPage";
 import PredictionPage from "./pages/PredictionPage";
 import TeamPage from "./pages/TeamPage";
+import Header from "./components/Header";
+import { appConfig } from "./constants";
 import { preloadTeamData } from "./branding/teamBranding";
 import { prefetchForRoute } from "./services/prefetchService";
 import "./App.css";
@@ -33,6 +35,9 @@ function RoutePrefetcher() {
 // Wraps the routed page in a container keyed by pathname, so each navigation
 // remounts it and replays a short fade-in (see `.pageFade` in index.css).
 // Keyed on pathname only, so in-page state changes (filters, week) don't fade.
+// Deliberately does NOT include the Header/Navigation — those live once in
+// <App> outside of <Routes> so they never remount (and the logo never
+// re-decodes/blinks) when navigating between tabs.
 function AnimatedRoutes() {
   const location = useLocation();
 
@@ -62,10 +67,20 @@ function App() {
     });
   }, []);
 
+  // Placeholder search handler shared by the single, persistent Header — no
+  // page currently wires up real search behavior (see TODOs on each page).
+  const handleSearch = (searchTerm) => {
+    console.log("Searching for:", searchTerm);
+  };
+
   return (
     <Router>
       <RoutePrefetcher />
       <div className="app">
+        {/* Persistent chrome: rendered once, outside <Routes>, so the nav bar
+            and logo stay mounted (no remount/re-decode blink) across every
+            navigation. Only the content below it swaps per route. */}
+        <Header title={appConfig.name} onSearch={handleSearch} />
         <AnimatedRoutes />
       </div>
     </Router>

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -17,77 +17,50 @@ const NAV_ITEMS = [
   { to: "/comparison", label: "Team Comparison" },
 ];
 
-// The Header (and this Navigation) remounts on every route change because each
-// page renders its own <Header>. Persist state at module scope across those
-// remounts:
-//   - the tab row's horizontal scroll position, and
-//   - the sliding indicator's last position, so on the next page it can animate
-//     FROM the previously-active tab TO the new one (instead of just appearing).
-let savedTabsScrollLeft = 0;
-let savedIndicator = { left: 0, width: 0, visible: false };
-let hasMountedOnce = false;
-
 const Navigation = () => {
   const location = useLocation();
   const tabsRef = useRef(null);
   const tabRefs = useRef([]);
-  // Seed from the persisted position so a navigation starts the underline/pill
-  // at the previously-active tab, then slides it to the new one.
-  const [indicator, setIndicator] = useState(savedIndicator);
-  // Animate from the very first render on a navigation (we've mounted before);
-  // on the first-ever mount, start without animating so it doesn't slide in
-  // from the origin.
-  const [animate, setAnimate] = useState(hasMountedOnce);
+  // Navigation is rendered once, outside <Routes>, as part of the persistent
+  // Header in App.jsx — it never unmounts on navigation, so plain state (no
+  // module-scope persistence) already survives route changes. This ref just
+  // distinguishes the very first mount from later re-renders triggered by a
+  // navigation, so the indicator can start in place (no slide-in from the
+  // origin) the first time, then glide FROM the previous tab TO the new one
+  // on every navigation after that.
+  const hasMountedRef = useRef(false);
+  const [indicator, setIndicator] = useState({ left: 0, width: 0, visible: false });
+  const [animate, setAnimate] = useState(false);
 
   const activeIndex = NAV_ITEMS.findIndex(
     (item) => item.to === location.pathname
   );
 
-  // Measure the active tab and move the shared underline/pill to sit under it,
-  // persisting the position so it survives the next remount.
+  // Measure the active tab and move the shared underline/pill to sit under it.
   const updateIndicator = useCallback(() => {
     const el = activeIndex >= 0 ? tabRefs.current[activeIndex] : null;
     if (el) {
-      const next = { left: el.offsetLeft, width: el.offsetWidth, visible: true };
-      savedIndicator = next;
-      setIndicator(next);
+      setIndicator({ left: el.offsetLeft, width: el.offsetWidth, visible: true });
     } else {
       // No matching tab (e.g. on a team detail page): keep last position but
       // fade the indicator out.
-      setIndicator((prev) => {
-        const next = { ...prev, visible: false };
-        savedIndicator = next;
-        return next;
-      });
+      setIndicator((prev) => ({ ...prev, visible: false }));
     }
   }, [activeIndex]);
 
   // Position the indicator. On the first-ever mount, do it synchronously before
-  // paint so it appears in place (no slide from origin). On later mounts (a
-  // navigation) the state already holds the previous tab's position, so defer
-  // the move to the next frame — that lets the old position paint first, and
-  // the change to the new tab animates.
+  // paint so it appears in place (no slide from origin). On every later
+  // render (a navigation), the state still holds the previous tab's position,
+  // so defer the move to the next frame — that lets the old position paint
+  // first, and the change to the new tab animates.
   useLayoutEffect(() => {
-    if (hasMountedOnce) {
+    if (hasMountedRef.current) {
       const id = requestAnimationFrame(() => updateIndicator());
       return () => cancelAnimationFrame(id);
     }
     updateIndicator();
-    hasMountedOnce = true;
+    hasMountedRef.current = true;
   }, [updateIndicator]);
-
-  // Restore the tab row's horizontal scroll position on mount (before paint)
-  // so navigating between pages never makes the bar jump.
-  useLayoutEffect(() => {
-    const el = tabsRef.current;
-    if (el) {
-      el.scrollLeft = savedTabsScrollLeft;
-    }
-  }, []);
-
-  const handleTabsScroll = (e) => {
-    savedTabsScrollLeft = e.currentTarget.scrollLeft;
-  };
 
   // Ensure animation is enabled shortly after the first mount, so later resizes
   // and font swaps animate too.
@@ -121,11 +94,7 @@ const Navigation = () => {
   return (
     <nav className={styles.navigation}>
       <div className={styles.navigationContainer}>
-        <div
-          className={styles.navigationTabs}
-          ref={tabsRef}
-          onScroll={handleTabsScroll}
-        >
+        <div className={styles.navigationTabs} ref={tabsRef}>
           {/* Sliding background highlight that glides behind the active tab. */}
           <span className={styles.navigationHighlight} style={indicatorStyle} />
           {NAV_ITEMS.map((item, index) => (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -151,30 +151,19 @@
   border-radius: var(--border-radius-sm);
 }
 
-/* Smooth fade-in on each route change. The wrapper is keyed by pathname
-   (see AnimatedRoutes in App.jsx), so it replays on every navigation. Opacity
-   only — no transform — so the sticky header doesn't shift during the fade.
-   The header itself lives outside this wrapper entirely (persistent chrome in
-   App.jsx), so it never fades or remounts.
+/* Layout container for the routed page content, sitting below the
+   persistent header (see AnimatedRoutes in App.jsx). This used to also
+   carry a keyed fade-in animation that replayed on every navigation — that
+   was the source of a visible flicker (an opacity dip on an otherwise
+   already-rendered page), so it's been removed; navigation is now instant,
+   with no animation and no forced remount.
    flex: 1 + column so this wrapper (and the routed page's own root element
    inside it) stretch to fill the remaining height below the header, the same
    way the page root used to via its own `min-height: 100vh`. */
-.pageFade {
-  animation: pageFadeIn 0.2s var(--ease-smooth);
+.routeOutlet {
   display: flex;
   flex-direction: column;
   flex: 1;
-}
-
-@keyframes pageFadeIn {
-  from {
-    /* Start mostly-visible, not fully transparent, so navigation reads as a
-       gentle settle rather than a blank-frame "blink". */
-    opacity: 0.6;
-  }
-  to {
-    opacity: 1;
-  }
 }
 
 /* Respect users who prefer reduced motion — keep the UI functional but calm. */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -153,9 +153,17 @@
 
 /* Smooth fade-in on each route change. The wrapper is keyed by pathname
    (see AnimatedRoutes in App.jsx), so it replays on every navigation. Opacity
-   only — no transform — so the sticky header doesn't shift during the fade. */
+   only — no transform — so the sticky header doesn't shift during the fade.
+   The header itself lives outside this wrapper entirely (persistent chrome in
+   App.jsx), so it never fades or remounts.
+   flex: 1 + column so this wrapper (and the routed page's own root element
+   inside it) stretch to fill the remaining height below the header, the same
+   way the page root used to via its own `min-height: 100vh`. */
 .pageFade {
   animation: pageFadeIn 0.2s var(--ease-smooth);
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
 @keyframes pageFadeIn {

--- a/frontend/src/pages/ComparisonPage.jsx
+++ b/frontend/src/pages/ComparisonPage.jsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { useState, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import Header from "../components/Header";
-import { appConfig } from "../constants";
 import styles from "../styles/pages/ComparisonPage.module.css";
 import api from "../services/api";
 import LoadingSpinner from "../components/LoadingSpinner";
@@ -61,11 +59,6 @@ const ComparisonPage = () => {
   useEffect(() => {
     writeStoredTeam(STORAGE_KEY_B, selectedTeamB);
   }, [selectedTeamB]);
-
-  const handleSearch = (searchTerm) => {
-    // MOCK FUNCTIONALITY - Replace with actual search API call
-    console.log("Searching for:", searchTerm);
-  };
 
   // Fetch teams list on component mount
   useEffect(() => {
@@ -250,7 +243,6 @@ const ComparisonPage = () => {
 
   return (
     <div className={styles.comparisonPage}>
-      <Header title={appConfig.name} onSearch={handleSearch} />
       <main className={styles.comparisonPageMain}>
         <div className={styles.comparisonPageContainer}>
           <div className={styles.comparisonPageHeader}>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from "react";
-import Header from "../components/Header";
 import ScoreCard from "../components/ScoreCard";
-import { appConfig } from "../constants";
 import api from "../services/api";
 import styles from "../styles/pages/HomePage.module.css";
 import { getCurrentWeek } from "../utils/helpers";
@@ -18,11 +16,6 @@ const HomePage = () => {
   const [gameData, setGameData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-
-  const handleSearch = (searchTerm) => {
-    // TODO: Replace with API call to /api/search
-    console.log("Searching for:", searchTerm);
-  };
 
   // Reset date filter when week or year changes
   useEffect(() => {
@@ -163,8 +156,6 @@ const HomePage = () => {
 
   return (
     <div className={styles.homePage}>
-      <Header title={appConfig.name} onSearch={handleSearch} />
-
       <main className={styles.homePageMain}>
         <div className={styles.homePageContainer}>
           <div className={styles.homePageHeader}>

--- a/frontend/src/pages/PredictionPage.jsx
+++ b/frontend/src/pages/PredictionPage.jsx
@@ -1,9 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { FiTarget, FiTrendingUp, FiCheckCircle, FiXCircle } from "react-icons/fi";
-import Header from "../components/Header";
 import TeamLogo from "../components/TeamLogo";
 import LoadingSpinner from "../components/LoadingSpinner";
-import { appConfig } from "../constants";
 import api from "../services/api";
 import { getCurrentWeek, getCurrentYear } from "../utils/helpers";
 import styles from "../styles/pages/PredictionPage.module.css";
@@ -169,8 +167,6 @@ const PredictionPage = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const handleSearch = () => {};
-
   useEffect(() => {
     const controller = new AbortController();
 
@@ -245,8 +241,6 @@ const PredictionPage = () => {
 
   return (
     <div className={styles.predictionPage}>
-      <Header title={appConfig.name} onSearch={handleSearch} />
-
       <main className={styles.predictionPageMain}>
         <div className={styles.predictionPageContainer}>
           <div className={styles.predictionPageHeader}>

--- a/frontend/src/pages/RankingsPage.jsx
+++ b/frontend/src/pages/RankingsPage.jsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from "react";
-import Header from "../components/Header";
 import RankingsTable from "../components/RankingsTable";
-import { appConfig } from "../constants";
 import api from "../services/api";
 import LoadingSpinner from "../components/LoadingSpinner";
 import styles from "../styles/pages/RankingsPage.module.css";
@@ -11,10 +9,6 @@ const RankingsPage = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const handleSearch = (searchTerm) => {
-    console.log("Searching for:", searchTerm);
-  };
-  
   useEffect(() => {
     const controller = new AbortController();
 
@@ -47,8 +41,6 @@ const RankingsPage = () => {
 
   return (
     <div className={styles.rankingsPage}>
-      <Header title={appConfig.name} onSearch={handleSearch} />
-
       <main className={styles.rankingsPageMain}>
         <div className={styles.rankingsPageContainer}>
           <div className={styles.rankingsPageHeader}>

--- a/frontend/src/pages/StatsPage.jsx
+++ b/frontend/src/pages/StatsPage.jsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from "react";
-import Header from "../components/Header";
 import StatsTable from "../components/StatsTable";
-import { appConfig } from "../constants";
 import { mockStats } from "../utils/mockData";
 import { statCategories } from "../utils/appData";
 import { getStats, hasBackendSupport, peekStats } from "../services/api";
@@ -13,11 +11,6 @@ const StatsPage = () => {
   const [stats, setStats] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-
-  const handleSearch = (searchTerm) => {
-    // TODO: Replace with API call to /api/search
-    console.log("Searching for:", searchTerm);
-  };
 
   // Fetch stats data when category changes
   useEffect(() => {
@@ -83,8 +76,6 @@ const StatsPage = () => {
 
   return (
     <div className={styles.statsPage}>
-      <Header title={appConfig.name} onSearch={handleSearch} />
-
       <main className={styles.statsPageMain}>
         <div className={styles.statsPageContainer}>
           <div className={styles.statsPageHeader}>

--- a/frontend/src/pages/TeamPage.jsx
+++ b/frontend/src/pages/TeamPage.jsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import Header from "../components/Header";
-import { appConfig } from "../constants";
 import styles from "../styles/pages/TeamPage.module.css";
 import api from "../services/api";
 import LoadingSpinner from "../components/LoadingSpinner";
@@ -18,12 +16,6 @@ const TeamPage = () => {
 
   // Decode the team name from URL
   const teamName = encodedTeamName ? decodeURIComponent(encodedTeamName) : null;
-
-  const handleSearch = (searchTerm) => {
-    // Search functionality will be handled by Header/SearchBar
-    // This is just a placeholder to match the interface
-    console.log("Searching for:", searchTerm);
-  };
 
   // Fetch team data when component mounts or teamName changes
   useEffect(() => {
@@ -60,7 +52,6 @@ const TeamPage = () => {
   if (loading) {
     return (
       <div className={styles.teamPage}>
-        <Header title={appConfig.name} onSearch={handleSearch} />
         <main className={styles.teamPageMain}>
           <div className={styles.loadingContainer}>
             <LoadingSpinner />
@@ -73,7 +64,6 @@ const TeamPage = () => {
   if (error || !teamData) {
     return (
       <div className={styles.teamPage}>
-        <Header title={appConfig.name} onSearch={handleSearch} />
         <main className={styles.teamPageMain}>
           <div className={styles.teamPageContainer}>
             <div className={styles.errorContainer}>
@@ -93,7 +83,6 @@ const TeamPage = () => {
 
   return (
     <div className={styles.teamPage}>
-      <Header title={appConfig.name} onSearch={handleSearch} />
       <main className={styles.teamPageMain}>
         <div className={styles.teamPageContainer}>
           <div className={styles.teamPageHeader}>

--- a/frontend/src/pages/TeamsPage.jsx
+++ b/frontend/src/pages/TeamsPage.jsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import Header from "../components/Header";
-import { appConfig } from "../constants";
 import api from "../services/api";
 import styles from "../styles/pages/TeamsPage.module.css";
 import LoadingSpinner from "../components/LoadingSpinner";
@@ -152,11 +150,6 @@ const TeamsPage = () => {
     });
   };
 
-  const handleSearch = (searchTerm) => {
-    // MOCK FUNCTIONALITY - Replace with actual search API call
-    console.log("Searching for:", searchTerm);
-  };
-
   useEffect(() => {
     const fetchTeams = async () => {
       setLoading(true);
@@ -212,8 +205,6 @@ const TeamsPage = () => {
 
   return (
     <div className={styles.teamsPage}>
-      <Header title={appConfig.name} onSearch={handleSearch} />
-
       <main className={styles.teamsPageMain}>
         <div className={styles.teamsPageContainer}>
           <div className={styles.teamsPageHeader}>

--- a/frontend/src/styles/pages/ComparisonPage.module.css
+++ b/frontend/src/styles/pages/ComparisonPage.module.css
@@ -1,5 +1,5 @@
 /* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
-   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   this page in App.jsx, and the shared .routeOutlet wrapper (index.css) is the
    flex column that provides full-viewport height; this just fills the
    remaining space below the header. */
 .comparisonPage {

--- a/frontend/src/styles/pages/ComparisonPage.module.css
+++ b/frontend/src/styles/pages/ComparisonPage.module.css
@@ -1,5 +1,9 @@
+/* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
+   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   flex column that provides full-viewport height; this just fills the
+   remaining space below the header. */
 .comparisonPage {
-  min-height: 100vh;
+  flex: 1;
   display: flex;
   flex-direction: column;
   background-color: var(--color-background);

--- a/frontend/src/styles/pages/HomePage.module.css
+++ b/frontend/src/styles/pages/HomePage.module.css
@@ -1,5 +1,9 @@
+/* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
+   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   flex column that provides full-viewport height; this just fills the
+   remaining space below the header. */
 .homePage {
-  min-height: 100vh;
+  flex: 1;
   display: flex;
   flex-direction: column;
   background-color: var(--color-background);

--- a/frontend/src/styles/pages/HomePage.module.css
+++ b/frontend/src/styles/pages/HomePage.module.css
@@ -1,5 +1,5 @@
 /* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
-   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   this page in App.jsx, and the shared .routeOutlet wrapper (index.css) is the
    flex column that provides full-viewport height; this just fills the
    remaining space below the header. */
 .homePage {

--- a/frontend/src/styles/pages/PredictionPage.module.css
+++ b/frontend/src/styles/pages/PredictionPage.module.css
@@ -1,5 +1,5 @@
 /* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
-   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   this page in App.jsx, and the shared .routeOutlet wrapper (index.css) is the
    flex column that provides full-viewport height; this just fills the
    remaining space below the header. */
 .predictionPage {

--- a/frontend/src/styles/pages/PredictionPage.module.css
+++ b/frontend/src/styles/pages/PredictionPage.module.css
@@ -1,5 +1,9 @@
+/* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
+   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   flex column that provides full-viewport height; this just fills the
+   remaining space below the header. */
 .predictionPage {
-  min-height: 100vh;
+  flex: 1;
   background-color: var(--color-background);
 }
 

--- a/frontend/src/styles/pages/RankingsPage.module.css
+++ b/frontend/src/styles/pages/RankingsPage.module.css
@@ -1,5 +1,5 @@
 /* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
-   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   this page in App.jsx, and the shared .routeOutlet wrapper (index.css) is the
    flex column that provides full-viewport height; this just fills the
    remaining space below the header. */
 .rankingsPage {

--- a/frontend/src/styles/pages/RankingsPage.module.css
+++ b/frontend/src/styles/pages/RankingsPage.module.css
@@ -1,5 +1,9 @@
+/* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
+   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   flex column that provides full-viewport height; this just fills the
+   remaining space below the header. */
 .rankingsPage {
-  min-height: 100vh;
+  flex: 1;
   display: flex;
   flex-direction: column;
   background-color: var(--color-background);

--- a/frontend/src/styles/pages/StatsPage.module.css
+++ b/frontend/src/styles/pages/StatsPage.module.css
@@ -1,5 +1,5 @@
 /* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
-   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   this page in App.jsx, and the shared .routeOutlet wrapper (index.css) is the
    flex column that provides full-viewport height; this just fills the
    remaining space below the header. */
 .statsPage {

--- a/frontend/src/styles/pages/StatsPage.module.css
+++ b/frontend/src/styles/pages/StatsPage.module.css
@@ -1,5 +1,9 @@
+/* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
+   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   flex column that provides full-viewport height; this just fills the
+   remaining space below the header. */
 .statsPage {
-  min-height: 100vh;
+  flex: 1;
   display: flex;
   flex-direction: column;
   background-color: var(--color-background);

--- a/frontend/src/styles/pages/TeamPage.module.css
+++ b/frontend/src/styles/pages/TeamPage.module.css
@@ -1,5 +1,9 @@
+/* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
+   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   flex column that provides full-viewport height; this just fills the
+   remaining space below the header. */
 .teamPage {
-  min-height: 100vh;
+  flex: 1;
   display: flex;
   flex-direction: column;
   background-color: var(--color-background);

--- a/frontend/src/styles/pages/TeamPage.module.css
+++ b/frontend/src/styles/pages/TeamPage.module.css
@@ -1,5 +1,5 @@
 /* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
-   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   this page in App.jsx, and the shared .routeOutlet wrapper (index.css) is the
    flex column that provides full-viewport height; this just fills the
    remaining space below the header. */
 .teamPage {

--- a/frontend/src/styles/pages/TeamsPage.module.css
+++ b/frontend/src/styles/pages/TeamsPage.module.css
@@ -1,5 +1,5 @@
 /* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
-   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   this page in App.jsx, and the shared .routeOutlet wrapper (index.css) is the
    flex column that provides full-viewport height; this just fills the
    remaining space below the header. */
 .teamsPage {

--- a/frontend/src/styles/pages/TeamsPage.module.css
+++ b/frontend/src/styles/pages/TeamsPage.module.css
@@ -1,5 +1,9 @@
+/* flex: 1 (not min-height: 100vh) — the persistent header now lives outside
+   this page in App.jsx, and the shared .pageFade wrapper (index.css) is the
+   flex column that provides full-viewport height; this just fills the
+   remaining space below the header. */
 .teamsPage {
-  min-height: 100vh;
+  flex: 1;
   display: flex;
   flex-direction: column;
   background-color: var(--color-background);


### PR DESCRIPTION
## Summary
Eliminates the visible flicker on every tab navigation by removing the pathname-keyed remount and fade-in animation from the route outlet wrapper. The animation was playing on an already-rendered page, creating a 60% opacity dip on every nav transition.

## Root Cause
The `AnimatedRoutes` wrapper was keyed by `location.pathname`, forcing React to unmount and remount the entire div (and everything inside) on every route change. This remount replayed the `pageFadeIn` animation (0.6 → 1.0 opacity), which created a visible flicker—an opacity dip—on top of the page already being rendered by `<Routes>`.

## Changes
- **frontend/src/App.jsx**: Removed `key={location.pathname}` from the routes wrapper div, changed class from `pageFade` to `routeOutlet` (layout-only), and updated comments to explain the fix.
- **frontend/src/index.css**: Removed `animation: pageFadeIn 0.2s var(--ease-smooth)` from `.pageFade`, deleted the `@keyframes pageFadeIn` block entirely, and renamed the class to `.routeOutlet` (kept its flex layout rules).
- **Page module.css files** (HomePage, RankingsPage, StatsPage, TeamsPage, TeamPage, ComparisonPage, PredictionPage): Comment-only updates referencing `.routeOutlet` instead of `.pageFade`.

## Testing
- Builds without errors
- No animation flicker on tab navigation
- Page content renders smoothly without the opacity dip
- Header and logo do not remount (fixed by prior commit 9728a89)

Generated with [Claude Code](https://claude.com/claude-code)