### PR TITLE
feat(matchup): CFBD teams dimension + league-wide weather backfill

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -59,9 +59,13 @@ CREATE TABLE IF NOT EXISTS teams (
     venue_name       TEXT,
     stadium_lat      DOUBLE PRECISION,            -- weather factor
     stadium_lon      DOUBLE PRECISION,
+    stadium_timezone TEXT,                        -- IANA tz of the venue; UTC->local date join for weather_history
     created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+-- Additive backfill for DBs created before stadium_timezone existed (the live
+-- troyster DB already has a teams table, which CREATE ... IF NOT EXISTS skips).
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS stadium_timezone TEXT;
 CREATE INDEX IF NOT EXISTS idx_teams_normalized_name ON teams (normalized_name);
 
 -- Layer 0 raw landing. Source-agnostic: source_type + JSONB payload absorb news,

--- a/ml/matchup_intel/db.py
+++ b/ml/matchup_intel/db.py
@@ -60,14 +60,18 @@ def upsert_team(
     venue_name: Optional[str] = None,
     stadium_lat: Optional[float] = None,
     stadium_lon: Optional[float] = None,
+    stadium_timezone: Optional[str] = None,
 ) -> str:
-    """Insert or update a team by normalized_name; returns team_id (UUID str)."""
+    """Insert or update a team by normalized_name; returns team_id (UUID str).
+    Every optional field is COALESCE'd so a partial upsert (e.g. the weather
+    backfill passing only coords) never nulls out data a richer upsert set."""
     normalized = normalize_team_name(name)
     row = conn.execute(
         """
         INSERT INTO teams (name, normalized_name, cfbd_id, conference,
-                           venue_name, stadium_lat, stadium_lon, updated_at)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, now())
+                           venue_name, stadium_lat, stadium_lon,
+                           stadium_timezone, updated_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, now())
         ON CONFLICT (normalized_name) DO UPDATE SET
             name       = COALESCE(EXCLUDED.name, teams.name),
             cfbd_id    = COALESCE(EXCLUDED.cfbd_id, teams.cfbd_id),
@@ -75,12 +79,33 @@ def upsert_team(
             venue_name = COALESCE(EXCLUDED.venue_name, teams.venue_name),
             stadium_lat = COALESCE(EXCLUDED.stadium_lat, teams.stadium_lat),
             stadium_lon = COALESCE(EXCLUDED.stadium_lon, teams.stadium_lon),
+            stadium_timezone = COALESCE(EXCLUDED.stadium_timezone, teams.stadium_timezone),
             updated_at = now()
         RETURNING team_id
         """,
-        (name, normalized, cfbd_id, conference, venue_name, stadium_lat, stadium_lon),
+        (name, normalized, cfbd_id, conference, venue_name,
+         stadium_lat, stadium_lon, stadium_timezone),
     ).fetchone()
     return str(row[0])
+
+
+def fetch_teams_with_coords(conn: psycopg.Connection) -> list[dict]:
+    """Every team that has stadium coordinates AND a timezone — the set the
+    weather backfill can ground. Returns [{name, stadium_lat, stadium_lon,
+    stadium_timezone}, ...]. Teams missing any of the three are skipped: the
+    UTC->local date join needs the tz, so a coord-only team can't be bucketed
+    correctly and is left out rather than joined against the wrong day."""
+    with conn.cursor(row_factory=dict_row) as cur:
+        return cur.execute(
+            """
+            SELECT name, stadium_lat, stadium_lon, stadium_timezone
+            FROM teams
+            WHERE stadium_lat IS NOT NULL
+              AND stadium_lon IS NOT NULL
+              AND stadium_timezone IS NOT NULL
+            ORDER BY name
+            """
+        ).fetchall()
 
 
 # --- raw_signals + watermarks ---------------------------------------------

--- a/ml/matchup_intel/ingest/teams_backfill.py
+++ b/ml/matchup_intel/ingest/teams_backfill.py
@@ -1,0 +1,80 @@
+"""Populate the teams dimension from CFBD — the foundation for real data.
+
+Pulls the FBS team list (with each team's nested venue location) from CFBD and
+upserts name / cfbd_id / conference / venue_name / stadium coords / timezone
+into the ``teams`` table. This is the prerequisite for the league-wide weather
+backfill (which reads stadium coords + tz straight back out of teams) and for
+keying factors by a real team_id instead of the two seeded demo teams.
+
+Idempotent: upsert-on-normalized_name, so re-running refreshes conference moves
+and venue changes without creating duplicates. Team NAMES come from the same
+CFBD source as training_data.csv (collect_data.py's /games), so teams.name lines
+up with the weather backfill's home_team join key.
+
+Run:  python -m ml.matchup_intel.ingest.teams_backfill [year]
+(needs CFBD_API_KEY + DATABASE_URL in the environment / ml/matchup_intel/.env)
+"""
+
+from __future__ import annotations
+
+from .. import db
+from ..sources import cfbd
+
+# CFBD's current-season FBS membership. Bumped as the default view of "who is
+# FBS"; historical weather still backfills from training_data.csv regardless.
+_DEFAULT_YEAR = 2024
+
+
+def backfill(database_url: str, cfbd_api_key: str, *, year: int = _DEFAULT_YEAR,
+             timeout: int = 30) -> dict:
+    """Upsert every FBS team for ``year`` into the teams dimension. Returns a
+    small summary {total, with_coords, without_coords}."""
+    teams = cfbd.fetch_fbs_teams(cfbd_api_key, year, timeout=timeout)
+    if not teams:
+        raise RuntimeError(
+            f"CFBD returned no FBS teams for {year}; refusing to proceed "
+            "(check CFBD_API_KEY and the year)."
+        )
+
+    total = with_coords = 0
+    with db.connect(database_url) as conn:
+        for raw in teams:
+            v = cfbd.team_venue(raw)
+            if not v["name"]:
+                continue  # can't key a team with no school name
+            db.upsert_team(
+                conn, v["name"],
+                cfbd_id=v["cfbd_id"],
+                conference=v["conference"],
+                venue_name=v["venue_name"],
+                stadium_lat=v["lat"],
+                stadium_lon=v["lon"],
+                stadium_timezone=v["timezone"],
+            )
+            total += 1
+            if v["lat"] is not None and v["lon"] is not None and v["timezone"]:
+                with_coords += 1
+
+    summary = {
+        "year": year,
+        "total": total,
+        "with_coords": with_coords,
+        "without_coords": total - with_coords,
+    }
+    print(f"[teams_backfill] {summary}")
+    return summary
+
+
+if __name__ == "__main__":
+    import sys
+
+    from ..config import load_config
+
+    cfg = load_config()
+    if not cfg.database_url:
+        raise RuntimeError("DATABASE_URL is not set (see ml/matchup_intel/env.example)")
+    if not cfg.cfbd_api_key:
+        raise RuntimeError("CFBD_API_KEY is not set (see ml/matchup_intel/env.example)")
+
+    year = int(sys.argv[1]) if len(sys.argv) > 1 else _DEFAULT_YEAR
+    backfill(cfg.database_url, cfg.cfbd_api_key, year=year, timeout=cfg.request_timeout)

--- a/ml/matchup_intel/ingest/weather_backfill.py
+++ b/ml/matchup_intel/ingest/weather_backfill.py
@@ -6,8 +6,9 @@ game, and writes the team's (bucket, won) history into weather_history. This
 replaces the seeded demo history with genuine data; the grounder + guard then
 serve (or withhold) a real win-rate depending on the real sample size.
 
-Bounded to a set of stadiums with known coordinates for now; extends by adding
-rows to STADIUMS (or, later, pulling coords from CFBD /venues).
+Stadiums are read from the teams dimension (coords + tz populated by
+ingest/teams_backfill.py from CFBD), so this covers every FBS venue with known
+coordinates rather than a hardcoded pair. Run teams_backfill first.
 """
 
 from __future__ import annotations
@@ -24,14 +25,27 @@ from ..sources import open_meteo
 
 _CSV = Path(__file__).resolve().parents[2] / "training_data" / "training_data.csv"
 
-# team display name -> (lat, lon, IANA tz) of home stadium. Public coordinates.
-# The tz is the stadium's local timezone — it must be passed to Open-Meteo
-# (instead of "auto") AND used to convert each game's UTC kickoff, so the two
-# sides of the date join agree (see _local_date()).
-STADIUMS = {
-    "Washington State": (46.7318, -117.1542, "America/Los_Angeles"),   # Martin Stadium, Pullman WA
-    "Oregon State": (44.5590, -123.2820, "America/Los_Angeles"),        # Reser Stadium, Corvallis OR
-}
+
+def _load_stadiums(database_url: str, only: set[str] | None = None) -> dict[str, tuple]:
+    """{team name: (lat, lon, IANA tz)} for every FBS team the teams dimension
+    has coords + tz for. The tz is the stadium's local timezone — passed to
+    Open-Meteo (instead of "auto") AND used to convert each game's UTC kickoff,
+    so the two sides of the date join agree (see _local_date()). ``only``
+    restricts to a subset of team names (handy for a quick test run)."""
+    with db.connect(database_url) as conn:
+        rows = db.fetch_teams_with_coords(conn)
+    stadiums = {
+        r["name"]: (r["stadium_lat"], r["stadium_lon"], r["stadium_timezone"])
+        for r in rows
+        if not only or r["name"] in only
+    }
+    if not stadiums:
+        raise RuntimeError(
+            "No teams have stadium coords + timezone yet. Run the teams "
+            "dimension backfill first: python -m ml.matchup_intel.ingest."
+            "teams_backfill"
+        )
+    return stadiums
 
 
 def _local_date(date_iso: str, tz_name: str) -> str:
@@ -69,16 +83,21 @@ def _home_games(teams: set[str], seasons: range) -> dict[str, list[tuple]]:
     return out
 
 
-def backfill(database_url: str, *, seasons: range = range(2003, 2025), timeout: int = 60) -> dict:
+def backfill(database_url: str, *, seasons: range = range(2003, 2025),
+             timeout: int = 60, only: set[str] | None = None) -> dict:
     """FETCH-THEN-WRITE, per team: all Open-Meteo HTTP calls happen with no DB
     connection open, results accumulate in memory, then a short-lived
     connection does the delete+bulk-insert and commits — so a mid-run network
     failure on one team doesn't lose already-completed teams, and no
-    transaction sits idle for the ~duration of a team's HTTP calls."""
-    games = _home_games(set(STADIUMS), seasons)
+    transaction sits idle for the ~duration of a team's HTTP calls.
+
+    Stadiums come from the teams dimension (see _load_stadiums); ``only`` limits
+    the run to a subset of team names for a quick smoke test."""
+    stadiums = _load_stadiums(database_url, only=only)
+    games = _home_games(set(stadiums), seasons)
     summary: dict[str, dict] = {}
 
-    for team, (lat, lon, tz_name) in STADIUMS.items():
+    for team, (lat, lon, tz_name) in stadiums.items():
         by_season: dict[int, list[tuple]] = defaultdict(list)
         for date_iso, season, won in games.get(team, []):
             by_season[season].append((_local_date(date_iso, tz_name), won))
@@ -102,7 +121,8 @@ def backfill(database_url: str, *, seasons: range = range(2003, 2025), timeout: 
 
         # --- write phase: short-lived connection, commits per team --------
         with db.connect(database_url) as conn:
-            team_id = db.upsert_team(conn, team, stadium_lat=lat, stadium_lon=lon)
+            team_id = db.upsert_team(conn, team, stadium_lat=lat, stadium_lon=lon,
+                                     stadium_timezone=tz_name)
             db.delete_weather_history_for_team(conn, team_id)   # idempotent refresh
             for bucket, results in bucket_rows.items():
                 db.insert_weather_history_bulk(conn, team_id, bucket, results,

--- a/ml/matchup_intel/sources/cfbd.py
+++ b/ml/matchup_intel/sources/cfbd.py
@@ -1,0 +1,93 @@
+"""College Football Data API client — the teams/venues dimension source.
+
+Authenticated (Bearer CFBD_API_KEY), read-only. Mirrors the retry/backoff +
+rate-limit pattern in ml/training_data/collect_data.py, kept dependency-free.
+
+Only the pieces the matchup engine needs live here: the FBS team list, which
+CFBD returns WITH its nested venue ``location`` (lat/lon, IANA timezone, venue
+name) — so one call yields the full teams dimension the weather backfill needs.
+The key is passed in explicitly (from Config) rather than read from the module
+env, so this stays a pure client with no import-time secret access.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+import requests
+
+CFBD_API_BASE_URL = "https://api.collegefootballdata.com"
+
+_REQUEST_DELAY = 0.11  # ~10 req/s ceiling, matching collect_data.py
+
+
+def _headers(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+
+
+def _get_with_retry(
+    url: str, api_key: str, params: Optional[dict], timeout: int, max_retries: int = 3
+):
+    """GET with rate-limiting + 429/backoff. Returns parsed JSON, or None on a
+    404. Raises RuntimeError once retries are exhausted — the teams dimension is
+    a required foundation, so a persistent failure must fail loudly rather than
+    silently seed an empty/partial teams table."""
+    headers = _headers(api_key)
+    for attempt in range(max_retries):
+        try:
+            time.sleep(_REQUEST_DELAY)
+            resp = requests.get(url, headers=headers, params=params, timeout=timeout)
+            if resp.status_code == 429:
+                if attempt < max_retries - 1:
+                    time.sleep(60)
+                    continue
+            elif resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            return resp.json()
+        except requests.RequestException as exc:
+            if attempt == max_retries - 1:
+                raise RuntimeError(
+                    f"CFBD request failed after {max_retries} attempts: {url} "
+                    f"params={params}"
+                ) from exc
+            time.sleep(2 ** attempt)
+    raise RuntimeError(
+        f"CFBD retries exhausted after {max_retries} attempts: {url} params={params}"
+    )
+
+
+def fetch_fbs_teams(api_key: str, year: int, timeout: int = 30) -> list[dict]:
+    """All FBS teams for a season, each with its nested venue ``location``.
+
+    Returns the raw CFBD team objects (list of dicts). Relevant fields:
+        id, school, conference,
+        location: {venue, latitude, longitude, timezone, dome, ...}
+    ``[]`` if CFBD returns nothing (404/empty)."""
+    data = _get_with_retry(
+        f"{CFBD_API_BASE_URL}/teams/fbs",
+        api_key,
+        {"year": year},
+        timeout,
+    )
+    return data if isinstance(data, list) else []
+
+
+def team_venue(team: dict) -> dict:
+    """Flatten one CFBD team object into the fields the teams dimension stores.
+
+    Returns {name, cfbd_id, conference, venue_name, lat, lon, timezone}. lat/lon/
+    timezone are None when CFBD has no venue on file for the team (e.g. a program
+    with no stadium record) — the caller stores the team either way; only the
+    weather backfill needs coords, and it already skips coord-less teams."""
+    loc = team.get("location") or {}
+    return {
+        "name": team.get("school"),
+        "cfbd_id": team.get("id"),
+        "conference": team.get("conference"),
+        "venue_name": loc.get("venue"),
+        "lat": loc.get("latitude"),
+        "lon": loc.get("longitude"),
+        "timezone": loc.get("timezone"),
+    }


### PR DESCRIPTION
Replace the seed-only foundations with real, league-wide data sources so weather grounding is honest for every FBS team, not just the two demo teams.

- sources/cfbd.py: authenticated CFBD client. One /teams/fbs pull yields each team WITH its nested venue (lat/lon, IANA timezone, venue name), so it feeds the whole teams dimension in a single call. Fails loudly on exhausted retries (the dimension is a required foundation), key passed in from Config.
- ingest/teams_backfill.py: upsert every FBS team into the teams dimension (idempotent on normalized_name; name matches training_data's home_team key).
- db/schema.sql: add teams.stadium_timezone (+ idempotent ALTER for the live DB) — required for the UTC->stadium-local date join in weather grounding.
- db.py: upsert_team carries stadium_timezone (all fields COALESCE-guarded); add fetch_teams_with_coords (only teams with coords AND tz are groundable).
- ingest/weather_backfill.py: read every FBS stadium from the teams dimension instead of a hardcoded 2-team dict; keep the fetch-then-write / per-team commit structure; add an `only={...}` subset for smoke tests.

Verified end-to-end against real CFBD + Open-Meteo + Postgres: 134 FBS teams loaded (126 with usable coords/tz), and real grounding e.g. Oregon State 28/41 in rain, Florida 16/17 in heat. 46 matchup_intel tests pass.