### PR TITLE
Add dedicated Polymarket history backfill workflow

### DIFF
--- a/.github/workflows/polymarket_backfill.yml
+++ b/.github/workflows/polymarket_backfill.yml
@@ -1,0 +1,76 @@
+name: Matchup Intel — Polymarket History Backfill
+
+# Manual-only (workflow_dispatch). Backfills the historical Polymarket
+# win-probability CURVE for every PAST game in the troyster `predictions` table
+# into `raw_signals`, so the Post-Game tab renders each game's market history.
+#
+# Kept SEPARATE from matchup_backfill.yml on purpose: this reaches out to the
+# public Polymarket APIs (gamma-api / clob) over the open internet — it needs no
+# CFBD key and doesn't touch the teams/weather grounding steps — and it can be
+# re-run at will (ingest is idempotent: each price point dedupes on content_hash).
+#
+# Reaches Postgres exactly like the other prod jobs: a GitHub-hosted runner joins
+# the tailnet (ephemeral tag:ci key) to hit troyster Postgres, which is not
+# publicly exposed. DATABASE_URL is a write-only secret injected at run time.
+
+on:
+  workflow_dispatch:
+    inputs:
+      fidelity:
+        description: "In-game sampling resolution in minutes (1 = per-minute)"
+        required: false
+        default: "1"
+
+# Serialize runs so two backfills never write the same prod rows concurrently.
+concurrency:
+  group: polymarket-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # `ml` is a namespace package — ensure repo root is importable for `-m`.
+      PYTHONPATH: ${{ github.workspace }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      # Deliberately NOT installing Prefect (same rationale as matchup_backfill):
+      # the pipeline's @task/@flow decorators degrade to plain functions when it's
+      # absent, which is the path the tests and local runs exercise.
+      - name: Install dependencies (no Prefect)
+        run: |
+          python -m pip install --upgrade pip
+          pip install "pydantic>=2.0" "psycopg[binary]>=3.1" requests python-dotenv PyYAML
+
+      # Join the tailnet so the runner can reach Postgres on troyster.
+      # Postgres is not publicly exposed; auth via a tagged ephemeral key (tag:ci).
+      # NOTE: the Polymarket API calls themselves egress over the OPEN INTERNET,
+      # not the tailnet — Tailscale is only for the DB write.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+          tags: tag:ci
+
+      - name: Backfill Polymarket history (all past games)
+        env:
+          POLYMARKET_FIDELITY: ${{ inputs.fidelity }}
+        run: python -m ml.matchup_intel.ingest.polymarket_ingest history
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          echo "::error::Polymarket history backfill failed — check the step logs above."
+          echo "Common causes: Tailscale/tag:ci lost tcp:5432 access, an expired"
+          echo "TS_AUTHKEY, a bad DATABASE_URL secret, or Polymarket API rate limits."

--- a/ml/matchup_intel/ingest/polymarket_ingest.py
+++ b/ml/matchup_intel/ingest/polymarket_ingest.py
@@ -186,6 +186,7 @@ def ingest_seed_odds(conn, timeout: int = 30) -> dict:
 
 
 if __name__ == "__main__":
+    import os
     import sys
 
     from ..config import load_config
@@ -197,6 +198,11 @@ if __name__ == "__main__":
     mode = sys.argv[1] if len(sys.argv) > 1 else "seed"
     with db.connect(cfg.database_url) as conn:
         if mode == "history":
-            print(backfill_all_history(conn, timeout=cfg.request_timeout))
+            # In-game sampling resolution (minutes); env override for the CI job.
+            try:
+                fidelity = int(os.environ.get("POLYMARKET_FIDELITY", "1"))
+            except ValueError:
+                fidelity = 1
+            print(backfill_all_history(conn, timeout=cfg.request_timeout, fidelity=fidelity))
         else:
             print(ingest_seed_odds(conn, timeout=cfg.request_timeout))


### PR DESCRIPTION
New manual workflow_dispatch job (.github/workflows/polymarket_backfill.yml) that backfills every past game's Polymarket win-probability curve into the troyster Postgres over Tailscale, so prod's Post-Game tab renders the history. Kept separate from matchup_backfill.yml: it egresses to the public Polymarket APIs, needs no CFBD key, and is independently re-runnable (idempotent ingest).

Wires POLYMARKET_FIDELITY through the ingest CLI's history mode.